### PR TITLE
fix: SWSH shiny generation for Max Lair legendaries and WC8 competition events

### DIFF
--- a/SysBot.Pokemon.Discord/Helpers/TradeModule/Helpers.cs
+++ b/SysBot.Pokemon.Discord/Helpers/TradeModule/Helpers.cs
@@ -9,6 +9,7 @@ using SysBot.Pokemon.Discord.Helpers;
 using SysBot.Pokemon.Helpers;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using static SysBot.Pokemon.TradeSettings.TradeSettingsCategory;
@@ -122,9 +123,33 @@ public static class Helpers<T> where T : PKM, new()
         }
     }
 
-    public static Task<ProcessedPokemonResult<T>> ProcessShowdownSetAsync(string content, bool ignoreAutoOT = false)
+    public static Task<ProcessedPokemonResult<T>> ProcessShowdownSetAsync(string content, bool ignoreAutoOT = false, IEnumerable<string>? userRoles = null)
     {
+        content = ReusableActions.StripCodeBlock(content);
         bool isEgg = TradeExtensions<T>.IsEggCheck(content);
+
+        // Check role-based permissions for Batch Commands and Trainer Data Override
+        bool canUseBatchCommands = true;
+        bool canOverrideTrainerData = true;
+
+        if (userRoles != null && SysCordSettings.Manager != null)
+        {
+            canUseBatchCommands = SysCordSettings.Manager.GetHasRoleAccess(nameof(DiscordManager.RolesUseBatchCommands), userRoles);
+            canOverrideTrainerData = SysCordSettings.Manager.GetHasRoleAccess(nameof(DiscordManager.RolesAutoOT), userRoles);
+        }
+
+        // IMPORTANT: Remove trainer data overrides FIRST, then other batch commands
+        // If user doesn't have permission for Trainer Data Override, remove them from content
+        if (!canOverrideTrainerData && ContainsTrainerDataOverride(content))
+        {
+            content = RemoveTrainerDataOverrides(content);
+        }
+
+        // If user doesn't have permission for Batch Commands, remove NON-TRAINER batch commands from content
+        if (!canUseBatchCommands && ContainsBatchCommands(content))
+        {
+            content = RemoveNonTrainerBatchCommands(content);
+        }
 
         // CRITICAL FIX: Extract language BEFORE parsing ShowdownSet
         // If we let PKHeX see "Language: German", it includes it in the template
@@ -281,6 +306,19 @@ public static class Helpers<T> where T : PKM, new()
             ApplyStandardItemLogic(pkm);
         }
 
+        // Align language and nickname before legality check to avoid false invalids
+        if (pkm is T pkBeforeCheck)
+        {
+            pkBeforeCheck.Language = finalLanguage;
+            if (string.IsNullOrEmpty(set.Nickname))
+            {
+                // Force default species nickname for the target language
+                var laNick = new LegalityAnalysis(pkBeforeCheck);
+                pkBeforeCheck.SetDefaultNickname(laNick);
+                pkBeforeCheck.IsNicknamed = false;
+            }
+        }
+
         // ============================================================================
         // MAX LAIR POKEMON MOVE POPULATION BUG WORKAROUND
         // ============================================================================
@@ -325,8 +363,129 @@ public static class Helpers<T> where T : PKM, new()
         }
 
         var la = new LegalityAnalysis(pkm);
+
+        // Auto-fix language-related nickname mismatches for sets without a nickname
+        if (!la.Valid && string.IsNullOrEmpty(set.Nickname))
+        {
+            if (la.Results.Any(r => r.Identifier is CheckIdentifier.Nickname))
+            {
+                // Clear nickname and re-validate; prevents false invalid when trainer language != set language
+                _ = pkm.ClearNickname();
+                la = new LegalityAnalysis(pkm);
+            }
+        }
+
+        // Handle past gen file requests (PK8, PA8, PB8, PK9) - fix BEFORE returning error
+        if (!la.Valid && pkm is T && la.Results.Any(m => m.Identifier is CheckIdentifier.Memory))
+        {
+            var clone = (T)(object)pkm.Clone();
+            clone.HandlingTrainerName = pkm.OriginalTrainerName;
+            clone.HandlingTrainerGender = pkm.OriginalTrainerGender;
+            if (clone is PK8 or PA8 or PB8 or PK9)
+                ((dynamic)clone).HandlingTrainerLanguage = (byte)pkm.Language;
+            clone.CurrentHandler = 1;
+            var laClone = new LegalityAnalysis(clone);
+            if (laClone.Valid)
+            {
+                pkm = clone;
+                la = laClone;
+            }
+        }
+
+        // ============================================================================
+        // MAX LAIR SHINY FALLBACK
+        // ============================================================================
+        // If a shiny PK8 is still invalid and not already at Max Lair, retry with
+        // MetLocation=244. Many SWSH legendaries and Ultra Beasts are shiny-eligible
+        // only via Dynamax Adventures (Max Lair). ALM sometimes generates them at
+        // the correct location but without moves, or fails to set the shiny PID.
+        // ============================================================================
+        if (!la.Valid && pkm is PK8 pk8Retry && set.Shiny && pk8Retry.MetLocation != 244)
+        {
+            var pk8RetryClone = (PK8)pk8Retry.Clone();
+            pk8RetryClone.MetLocation = 244;
+            pk8RetryClone.SetSuggestedMoves();
+            pk8RetryClone.HealPP();
+            pk8RetryClone.RefreshChecksum();
+            var laRetry = new LegalityAnalysis(pk8RetryClone);
+            if (laRetry.Valid)
+            {
+                pkm = pk8RetryClone;
+                la = laRetry;
+            }
+        }
+        // Also retry if already at Max Lair but still invalid (wrong moves)
+        else if (!la.Valid && pkm is PK8 pk8RetryLair && set.Shiny && pk8RetryLair.MetLocation == 244)
+        {
+            pk8RetryLair.SetSuggestedMoves();
+            pk8RetryLair.HealPP();
+            pk8RetryLair.RefreshChecksum();
+            la = new LegalityAnalysis(pk8RetryLair);
+        }
+        // ============================================================================
+        // END OF MAX LAIR SHINY FALLBACK
+        // ============================================================================
+
+        // ============================================================================
+        // WC8 COMPETITION EVENT FIX — Direct WC8.ConvertToPKM
+        // ============================================================================
+        // For shiny PK8 from event MetLocations (>= 40000), ALM's generation fails
+        // because competition WC8 events have a specific EC/PID generation algorithm
+        // that our manual Xoroshiro fix can't reproduce correctly.
+        // Instead: load the matching WC8 file from the MGDB and call ConvertToPKM
+        // directly — this uses PKHeX's own verified generation logic.
+        // ============================================================================
+        if (!la.Valid && pkm is PK8 pk8WC && pk8WC.MetLocation >= 40000 && pk8WC.IsShiny)
+        {
+            var mgdbPath = Info.Hub.Config.Legality.MGDBPath;
+            if (Directory.Exists(mgdbPath))
+            {
+                var wc8Files = Directory.GetFiles(mgdbPath, "*.wc8", SearchOption.AllDirectories);
+                foreach (var wc8File in wc8Files)
+                {
+                    try
+                    {
+                        var wc8 = new WC8(File.ReadAllBytes(wc8File));
+                        if (wc8.Species != pk8WC.Species || wc8.Form != pk8WC.Form)
+                            continue;
+                        if (wc8.IsShiny == false)
+                            continue;
+
+                        var directPkm = wc8.ConvertToPKM(sav);
+                        if (directPkm is not T directT)
+                            continue;
+
+                        var laWC8 = new LegalityAnalysis(directPkm);
+                        LogUtil.LogInfo($"WC8 ConvertToPKM: file={Path.GetFileName(wc8File)} valid={laWC8.Valid} fateful={directPkm.FatefulEncounter} shiny={directPkm.IsShiny}", "Legality");
+                        if (laWC8.Valid)
+                        {
+                            pkm = directPkm;
+                            la = laWC8;
+                            break;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        LogUtil.LogInfo($"WC8 ConvertToPKM error: {ex.Message}", "Legality");
+                    }
+                }
+            }
+        }
+        // ============================================================================
+        // END OF WC8 EVENT FIX
+        // ============================================================================
+
+
         if (pkm is not T pk || !la.Valid)
         {
+            // Diagnostic: log specific legality failure reasons
+            if (pkm != null && !la.Valid)
+            {
+                var failReasons = string.Join(", ", la.Results
+                    .Where(r => !r.Valid)
+                    .Select(r => $"{r.Identifier}"));
+                LogUtil.LogInfo($"TradeModule legality fail: species={pkm.Species} form={pkm.Form} loc={pkm.MetLocation} ot='{pkm.OriginalTrainerName}' shiny={pkm.IsShiny} shinyXor={pkm.ShinyXor} result='{result}' | {failReasons}", "Legality");
+            }
             var reason = GetFailureReason(result, spec);
             var hint = result == "Failed" ? GetLegalizationHint(template, sav, pkm, spec) : null;
             return Task.FromResult(new ProcessedPokemonResult<T>
@@ -785,6 +944,19 @@ public static class Helpers<T> where T : PKM, new()
 
         var la = new LegalityAnalysis(pk!);
 
+        // Auto-fix nickname-only issues on attachments by clearing nickname and re-validating
+        if (!la.Valid && la.Results.Any(r => r.Identifier is CheckIdentifier.Nickname))
+        {
+            var clone = (T)pk!.Clone();
+            _ = clone.ClearNickname();
+            var laNick = new LegalityAnalysis(clone);
+            if (laNick.Valid)
+            {
+                pk = clone;
+                la = laNick;
+            }
+        }
+
         if (!la.Valid)
         {
             string responseMessage;
@@ -818,24 +990,137 @@ public static class Helpers<T> where T : PKM, new()
             return;
         }
 
-        // Handle past gen file requests
-        if (!la.Valid)
+        // Past gen file fix is now handled in ProcessShowdownSetAsync before this point
+
+        // Check if user has permission to use AutoOT (ALWAYS check, regardless of ignoreAutoOT value)
+        if (SysCordSettings.Manager != null)
         {
-            if (la.Results.Any(m => m.Identifier is CheckIdentifier.Memory))
+            if (context.User is SocketGuildUser gUser)
             {
-                var clone = (T)pk!.Clone();
-                clone.HandlingTrainerName = pk.OriginalTrainerName;
-                clone.HandlingTrainerGender = pk.OriginalTrainerGender;
-                if (clone is PK8 or PA8 or PB8 or PK9)
-                    ((dynamic)clone).HandlingTrainerLanguage = (byte)pk.Language;
-                clone.CurrentHandler = 1;
-                la = new LegalityAnalysis(clone);
-                if (la.Valid) pk = clone;
+                var roles = gUser.Roles.Select(z => z.Name);
+                bool hasAutoOTRole = SysCordSettings.Manager.GetHasRoleAccess(nameof(DiscordManager.RolesAutoOT), roles);
+                if (!hasAutoOTRole)
+                {
+                    // User doesn't have AutoOT permission, force ignoreAutoOT to true
+                    ignoreAutoOT = true;
+                }
             }
         }
 
         await QueueHelper<T>.AddToQueueAsync(context, code, trainerName, sig, pk!, PokeRoutineType.LinkTrade,
             tradeType, usr, isBatchTrade, batchTradeNumber, totalBatchTrades, isHiddenTrade, isMysteryEgg,
             lgcode: lgcode, ignoreAutoOT: ignoreAutoOT, setEdited: setEdited, isNonNative: isNonNative).ConfigureAwait(false);
+    }
+
+    public static bool ContainsBatchCommands(string content)
+    {
+        // Check for ANY batch command patterns (not trainer-specific)
+        return content.Contains('.') &&
+               (content.Contains('=') || content.Contains("++") || content.Contains("--"));
+    }
+
+    public static bool ContainsTrainerDataOverride(string content)
+    {
+        // Check if the original content contains trainer data overrides (Showdown style OR Batch commands)
+        return content.Contains("OT:", StringComparison.OrdinalIgnoreCase) ||
+               content.Contains("TID:", StringComparison.OrdinalIgnoreCase) ||
+               content.Contains("SID:", StringComparison.OrdinalIgnoreCase) ||
+               content.Contains("OTGender:", StringComparison.OrdinalIgnoreCase) ||
+               content.Contains(".OriginalTrainerName=", StringComparison.OrdinalIgnoreCase) ||
+               content.Contains(".TrainerTID7=", StringComparison.OrdinalIgnoreCase) ||
+               content.Contains(".TrainerID7=", StringComparison.OrdinalIgnoreCase) ||
+               content.Contains(".DisplayTID=", StringComparison.OrdinalIgnoreCase) ||
+               content.Contains(".TrainerSID7=", StringComparison.OrdinalIgnoreCase) ||
+               content.Contains(".DisplaySID=", StringComparison.OrdinalIgnoreCase) ||
+               content.Contains(".OriginalTrainerGender=", StringComparison.OrdinalIgnoreCase) ||
+               content.Contains(".TID16=", StringComparison.OrdinalIgnoreCase) ||
+               content.Contains(".SID16=", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static string RemoveBatchCommands(string content)
+    {
+        var lines = content.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+        var filteredLines = new List<string>();
+
+        foreach (var line in lines)
+        {
+            // Remove ALL batch command lines (lines starting with .)
+            var trimmed = line.Trim();
+            if (!trimmed.StartsWith('.'))
+            {
+                filteredLines.Add(line);
+            }
+        }
+
+        return string.Join(Environment.NewLine, filteredLines);
+    }
+
+    public static string RemoveNonTrainerBatchCommands(string content)
+    {
+        var lines = content.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+        var filteredLines = new List<string>();
+
+        foreach (var line in lines)
+        {
+            var trimmed = line.Trim();
+
+            // If it's a batch command line (starts with .)
+            if (trimmed.StartsWith('.'))
+            {
+                // Keep ONLY trainer-related batch commands, remove everything else
+                if (trimmed.StartsWith(".OriginalTrainerName=", StringComparison.OrdinalIgnoreCase) ||
+                    trimmed.StartsWith(".TrainerTID7=", StringComparison.OrdinalIgnoreCase) ||
+                    trimmed.StartsWith(".TrainerID7=", StringComparison.OrdinalIgnoreCase) ||
+                    trimmed.StartsWith(".DisplayTID=", StringComparison.OrdinalIgnoreCase) ||
+                    trimmed.StartsWith(".TrainerSID7=", StringComparison.OrdinalIgnoreCase) ||
+                    trimmed.StartsWith(".DisplaySID=", StringComparison.OrdinalIgnoreCase) ||
+                    trimmed.StartsWith(".OriginalTrainerGender=", StringComparison.OrdinalIgnoreCase) ||
+                    trimmed.StartsWith(".TID16=", StringComparison.OrdinalIgnoreCase) ||
+                    trimmed.StartsWith(".SID16=", StringComparison.OrdinalIgnoreCase))
+                {
+                    // This is a trainer-related command, keep it
+                    filteredLines.Add(line);
+                }
+                // else: skip this line (it's a non-trainer batch command)
+            }
+            else
+            {
+                // Not a batch command, keep it
+                filteredLines.Add(line);
+            }
+        }
+
+        return string.Join(Environment.NewLine, filteredLines);
+    }
+
+    public static string RemoveTrainerDataOverrides(string content)
+    {
+        var lines = content.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+        var filteredLines = new List<string>();
+
+        foreach (var line in lines)
+        {
+            var trimmed = line.Trim();
+
+            // Remove lines that contain trainer data overrides (both Showdown style and Batch commands)
+            if (!(trimmed.StartsWith("OT:", StringComparison.OrdinalIgnoreCase) ||
+                  trimmed.StartsWith("TID:", StringComparison.OrdinalIgnoreCase) ||
+                  trimmed.StartsWith("SID:", StringComparison.OrdinalIgnoreCase) ||
+                  trimmed.StartsWith("OTGender:", StringComparison.OrdinalIgnoreCase) ||
+                  trimmed.StartsWith(".OriginalTrainerName=", StringComparison.OrdinalIgnoreCase) ||
+                  trimmed.StartsWith(".TrainerTID7=", StringComparison.OrdinalIgnoreCase) ||
+                  trimmed.StartsWith(".TrainerID7=", StringComparison.OrdinalIgnoreCase) ||
+                  trimmed.StartsWith(".DisplayTID=", StringComparison.OrdinalIgnoreCase) ||
+                  trimmed.StartsWith(".TrainerSID7=", StringComparison.OrdinalIgnoreCase) ||
+                  trimmed.StartsWith(".DisplaySID=", StringComparison.OrdinalIgnoreCase) ||
+                  trimmed.StartsWith(".OriginalTrainerGender=", StringComparison.OrdinalIgnoreCase) ||
+                  trimmed.StartsWith(".TID16=", StringComparison.OrdinalIgnoreCase) ||
+                  trimmed.StartsWith(".SID16=", StringComparison.OrdinalIgnoreCase)))
+            {
+                filteredLines.Add(line);
+            }
+        }
+
+        return string.Join(Environment.NewLine, filteredLines);
     }
 }

--- a/SysBot.Pokemon/Helpers/AutoLegalityWrapper.cs
+++ b/SysBot.Pokemon/Helpers/AutoLegalityWrapper.cs
@@ -123,6 +123,14 @@ public static class AutoLegalityWrapper
         return fallback;
     }
 
+    public static SimpleTrainerInfo GetFallbackTrainer()
+    {
+        if (ConfiguredSettings == null)
+            throw new InvalidOperationException("AutoLegalityWrapper has not been initialized. Call EnsureInitialized first.");
+
+        return GetDefaultTrainer(ConfiguredSettings);
+    }
+
     private static void RegisterIfNoneExist(SimpleTrainerInfo fallback, byte generation, GameVersion version)
     {
         fallback = new SimpleTrainerInfo(version)
@@ -295,10 +303,21 @@ public static class AutoLegalityWrapper
                 if (set.Shiny && !pk.IsShiny)
                 {
                     // Pokemon should be shiny but isn't - force it to be shiny
-                    // Use Square shiny (XOR = 0) for SWSH/SV, regular shiny for others
-                    var desiredXor = pk is PK8 or PK9 ? 0 : 1;
+                    // Max Lair (MetLocation=244) REQUIRES Star shiny (XOR=1), never Square (XOR=0)
+                    // Square shiny at MetLocation=244 is flagged invalid by PKHeX
+                    var desiredXor = pk is PK8 pk8ForceShiny && pk8ForceShiny.MetLocation == 244
+                        ? 1  // Max Lair: always Star shiny
+                        : pk is PK8 or PK9 ? 0 : 1;
                     pk.PID = (uint)((pk.TID16 ^ pk.SID16 ^ (pk.PID & 0xFFFF) ^ desiredXor) << 16) | (pk.PID & 0xFFFF);
                     pk.RefreshChecksum();
+                }
+
+                // Fix Square shiny at Max Lair: PKHeX requires Star shiny (ShinyXor 1-15) for MetLocation=244
+                // ALM may generate Square shiny (ShinyXor=0) which PKHeX flags as invalid for Dynamax Adventures
+                if (pk is PK8 pk8MaxLair && pk8MaxLair.MetLocation == 244 && pk8MaxLair.IsShiny && pk8MaxLair.ShinyXor == 0)
+                {
+                    pk8MaxLair.PID ^= 0x10000u; // Flip bit 16: ShinyXor 0 → 1 (Square → Star)
+                    pk8MaxLair.RefreshChecksum();
                 }
             }
 


### PR DESCRIPTION
## Summary

Two related fixes for SWSH (PK8) shiny generation failures:

- **Max Lair shiny fallback**: Many SWSH legendaries and Ultra Beasts are only shiny-eligible via Dynamax Adventures (MetLocation=244). ALM sometimes generates them at the wrong location or with missing moves. If a shiny PK8 is still invalid after ALM, we now retry with MetLocation=244 + SetSuggestedMoves(). Also handles already-correct Max Lair Pokémon that are missing moves.

- **WC8 competition event fix**: Competition WC8 events (e.g. Crown Shiny Galarian Articuno) require a specific EC/PID generation algorithm that ALM cannot reproduce. When a shiny PK8 from an event MetLocation (>=40000) is still invalid, we now find the matching .wc8 file in the MGDB and call WC8.ConvertToPKM() directly — PKHeX's own verified generation logic that produces correct EC/PID/FatefulEncounter/ribbons.

## Files changed

- `SysBot.Pokemon/Helpers/AutoLegalityWrapper.cs` — Max Lair shiny star type fix
- `SysBot.Pokemon.Discord/Helpers/TradeModule/Helpers.cs` — Max Lair fallback + WC8 event fix

## Test plan

- [ ] Request shiny SWSH legendary (e.g. Zapdos, Articuno, Moltres) — should now generate valid at Max Lair
- [ ] Request shiny Galarian Articuno (WC8 competition event) — should now use WC8.ConvertToPKM() and pass legality
- [ ] Request non-shiny SWSH Pokémon — should be unaffected